### PR TITLE
Excludes ppc64 from kext support tools build.

### DIFF
--- a/osxfusefs.xcodeproj/project.pbxproj
+++ b/osxfusefs.xcodeproj/project.pbxproj
@@ -719,6 +719,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				INSTALL_PATH = "$(HOME)/bin";
 				PRODUCT_NAME = mount_osxfusefs;
+				VALID_ARCHS = "i386 ppc ppc7400 x86_64";
 			};
 			name = Debug;
 		};
@@ -758,6 +759,7 @@
 				LINK_WITH_STANDARD_LIBRARIES = YES;
 				PRODUCT_NAME = mount_osxfusefs;
 				STRIP_INSTALLED_PRODUCT = YES;
+				VALID_ARCHS = "i386 ppc ppc7400 x86_64";
 			};
 			name = Release;
 		};
@@ -842,6 +844,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				INSTALL_PATH = "$(HOME)/bin";
 				PRODUCT_NAME = load_osxfusefs;
+				VALID_ARCHS = "i386 ppc ppc7400 x86_64";
 			};
 			name = Debug;
 		};
@@ -880,6 +883,7 @@
 				INSTALL_PATH = "$(HOME)/bin";
 				PRODUCT_NAME = load_osxfusefs;
 				STRIP_INSTALLED_PRODUCT = YES;
+				VALID_ARCHS = "i386 ppc ppc7400 x86_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Due to some as yet not understood bug, recent builds (>=V2.6.2)
of these tools have contained broken ppc64 content, resulting
in unusability on G5s.  This change excludes the broken content,
and has no effect on builds for >=10.6, where PPC is unsupported.

Although the bad builds (presumably under Xcode 3.2) are not
reproducible here, the effect of omitting the ppc64 "forks"
has been tested with Xcode 3.1.
