### PR TITLE
vnode cache: ignore cache hits when creating a file

### DIFF
--- a/osxfuse/fuse_vnops.c
+++ b/osxfuse/fuse_vnops.c
@@ -1587,7 +1587,11 @@ fuse_vnop_lookup(struct vnop_lookup_args *ap)
         switch (err) {
 
         case -1: /* positive match */
-            if (fuse_isnovncache(*vpp)) {
+            /* We ignore cache hits when trying to create a file.
+             * Indeed, the file could have disappeared below us,
+             * and we do not want to return EEXIST in that case,
+             * so we let the underlying filesystem decide. */
+            if (fuse_isnovncache(*vpp) || (nameiop == CREATE)) {
                 fuse_vncache_purge(*vpp);
 #if M_OSXFUSE_ENABLE_BIG_LOCK
                 fuse_biglock_unlock(data->biglock);


### PR DESCRIPTION
This fixes a problem which occurs when a file has been removed in the underlying filesystem (not through FUSE). The vnode cache may not know about this, and FUSE will return EEXIST. By ignoring cache hits in this case, we ensure that attempts to recreate the file will succeed.