### PR TITLE
Unset FN_REVOKED flag when recycling a node

### DIFF
--- a/osxfuse/fuse_node.c
+++ b/osxfuse/fuse_node.c
@@ -67,6 +67,14 @@ FSNodeGetOrCreateFileVNodeByID(vnode_t              *vnPtr,
 
     err = HNodeLookupCreatingIfNecessary(dummy_device, fuse_entry_out_get_nodeid(feo),
                                          0 /* fork index */, &hn, &vn);
+
+    if ((err == 0) && (vn != NULL)) {
+        /* If the vnode is re-used, we may have to clear FN_REVOKED.
+         * This can happen, for instance, if a directory is created,
+         * removed and re-created in the underlying filesystem. */
+        VTOFUD(vn)->flag &= ~FN_REVOKED;
+    }
+
     if ((err == 0) && (vn == NULL)) {
 
         struct vnode_fsparam params;


### PR DESCRIPTION
When the vnode cache is enabled, if a file has been removed and re-created in the underlying filesystem (not through FUSE), `HNodeLookupCreatingIfNecessary` can return revoked nodes (this ends up killing the filesystem). By clearing the flag, we re-use the vnode anyway and avoids this issue.
