### PR TITLE
Add FSEvents notifications

### DIFF
--- a/osxfuse.xcodeproj/project.pbxproj
+++ b/osxfuse.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		4332BEFB1D10926200F84D51 /* fuse_param.h in Headers */ = {isa = PBXBuildFile; fileRef = 4332BEF61D10926200F84D51 /* fuse_param.h */; };
 		4332BEFC1D10926200F84D51 /* fuse_preprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 4332BEF71D10926200F84D51 /* fuse_preprocessor.h */; };
 		4332BEFD1D10926200F84D51 /* fuse_version.h in Headers */ = {isa = PBXBuildFile; fileRef = 4332BEF81D10926200F84D51 /* fuse_version.h */; };
+		8B7108E91D9AE876005BE2C6 /* fuse_fsevents.c in Sources */ = {isa = PBXBuildFile; fileRef = 8B7108E71D9AE876005BE2C6 /* fuse_fsevents.c */; };
+		8B7108EA1D9AE876005BE2C6 /* fuse_fsevents.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B7108E81D9AE876005BE2C6 /* fuse_fsevents.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -81,6 +83,8 @@
 		4332BEF61D10926200F84D51 /* fuse_param.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_param.h; sourceTree = "<group>"; };
 		4332BEF71D10926200F84D51 /* fuse_preprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_preprocessor.h; sourceTree = "<group>"; };
 		4332BEF81D10926200F84D51 /* fuse_version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_version.h; sourceTree = "<group>"; };
+		8B7108E71D9AE876005BE2C6 /* fuse_fsevents.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fuse_fsevents.c; sourceTree = "<group>"; };
+		8B7108E81D9AE876005BE2C6 /* fuse_fsevents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_fsevents.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +145,8 @@
 				4332BECD1D10900700F84D51 /* fuse_vfsops.c */,
 				4332BECE1D10900700F84D51 /* fuse_vfsops.h */,
 				4332BECF1D10900700F84D51 /* fuse_vnops.c */,
+				8B7108E71D9AE876005BE2C6 /* fuse_fsevents.c */,
+				8B7108E81D9AE876005BE2C6 /* fuse_fsevents.h */,
 				4332BED01D10900700F84D51 /* fuse_vnops.h */,
 				4332BED11D10900700F84D51 /* fuse.h */,
 				4332BEAD1D108F4000F84D51 /* Info.plist */,
@@ -176,6 +182,7 @@
 				4332BEDC1D10900700F84D51 /* fuse_kernel.h in Headers */,
 				4332BEDE1D10900700F84D51 /* fuse_kludges.h in Headers */,
 				4332BEFC1D10926200F84D51 /* fuse_preprocessor.h in Headers */,
+				8B7108EA1D9AE876005BE2C6 /* fuse_fsevents.h in Headers */,
 				4332BEE21D10900700F84D51 /* fuse_locking.h in Headers */,
 				4332BEEF1D10900700F84D51 /* fuse_vnops.h in Headers */,
 				4332BEE71D10900700F84D51 /* fuse_nodehash.h in Headers */,
@@ -280,6 +287,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B7108E91D9AE876005BE2C6 /* fuse_fsevents.c in Sources */,
 				4332BEE11D10900700F84D51 /* fuse_locking.c in Sources */,
 				4332BEE81D10900700F84D51 /* fuse_notify.c in Sources */,
 				4332BEDA1D10900700F84D51 /* fuse_ipc.c in Sources */,

--- a/osxfuse/fuse_fsevents.c
+++ b/osxfuse/fuse_fsevents.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016 EditShare LLC
+ * All rights reserved.
+ */
+
+#include "fuse_fsevents.h"
+
+#if VERSION_MAJOR >= 15
+
+void
+fsevent(vnode_t vp, uint32_t hint)
+{
+    struct vnode_attr vattr;
+
+    vfs_get_notify_attributes(&vattr);
+    vnode_notify(vp, hint, &vattr);
+}
+
+#endif

--- a/osxfuse/fuse_fsevents.h
+++ b/osxfuse/fuse_fsevents.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 EditShare LLC
+ * All rights reserved.
+ */
+
+#ifndef _FUSE_FSEVENTS_H_
+#define _FUSE_FSEVENTS_H_
+
+#include "fuse.h"
+
+#include <libkern/version.h>
+
+#define VNODE_EVENT_DELETE 0x00000001
+#define VNODE_EVENT_WRITE  0x00000002
+#define VNODE_EVENT_EXTEND 0x00000004
+#define VNODE_EVENT_ATTRIB 0x00000008
+#define VNODE_EVENT_LINK   0x00000010
+#define VNODE_EVENT_RENAME 0x00000020
+
+#if VERSION_MAJOR >= 15
+#define FUSE_FSEVENT(vp, hint) fsevent(vp, hint)
+extern void fsevent(vnode_t vp, uint32_t hint);
+#else
+#define FUSE_FSEVENT(vp, hint) do {} while(0)
+#endif
+
+#endif /* _FUSE_FSEVENT_H_ */

--- a/osxfuse/fuse_notify.c
+++ b/osxfuse/fuse_notify.c
@@ -6,6 +6,7 @@
 #include "fuse_notify.h"
 
 #include "fuse_biglock_vnops.h"
+#include "fuse_fsevents.h"
 #include "fuse_internal.h"
 #include "fuse_ipc.h"
 #include "fuse_node.h"
@@ -87,6 +88,8 @@ fuse_notify_getattr(void *parameter, __unused wait_result_t wait_result)
     }
 
 out:
+    FUSE_FSEVENT(vp, VNODE_EVENT_ATTRIB);
+
     /*
      * Note: We need to unlock the node and decrement the vnode's iocount. See
      * fuse_notify_inval_inode for details.
@@ -170,6 +173,7 @@ fuse_notify_inval_entry(struct fuse_data *data, struct fuse_iov *iov)
     }
 
     fuse_invalidate_attr(dvp);
+    FUSE_FSEVENT(dvp, VNODE_EVENT_ATTRIB);
 
 out:
     fuse_nodelock_unlock(VTOFUD(dvp));
@@ -255,6 +259,7 @@ fuse_notify_inval_inode(struct fuse_data *data, struct fuse_iov *iov)
         }
     }
 
+    FUSE_FSEVENT(vp, VNODE_EVENT_ATTRIB);
     fuse_nodelock_unlock(VTOFUD(vp));
     vnode_put(vp);
 

--- a/osxfuse/fuse_vnops.c
+++ b/osxfuse/fuse_vnops.c
@@ -9,6 +9,7 @@
 #include "fuse_vnops.h"
 
 #include "fuse_file.h"
+#include "fuse_fsevents.h"
 #include "fuse_internal.h"
 #include "fuse_ipc.h"
 #include "fuse_node.h"
@@ -575,6 +576,8 @@ bringup:
 
     fuse_ticket_release(fdip->tick);
 
+    FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE);
+
     return 0;
 
 undo:
@@ -675,6 +678,11 @@ out:
 
     vnode_putname(fname);
     vnode_putname(tname);
+
+    if (err == 0) {
+        FUSE_FSEVENT(fvp, VNODE_EVENT_ATTRIB);
+        FUSE_FSEVENT(tvp, VNODE_EVENT_ATTRIB);
+    }
 
     return err;
 
@@ -1389,6 +1397,9 @@ fuse_vnop_link(struct vnop_link_args *ap)
 #if M_OSXFUSE_ENABLE_BIG_LOCK
         fuse_biglock_lock(data->biglock);
 #endif
+
+        FUSE_FSEVENT(vp, VNODE_EVENT_LINK);
+        FUSE_FSEVENT(tdvp, VNODE_EVENT_WRITE);
     }
 
     return err;
@@ -1843,6 +1854,7 @@ fuse_vnop_mkdir(struct vnop_mkdir_args *ap)
 
     if (err == 0) {
         fuse_invalidate_attr(dvp);
+        FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE | VNODE_EVENT_LINK);
     }
 
     return err;
@@ -1897,6 +1909,7 @@ fuse_vnop_mknod(struct vnop_mknod_args *ap)
 
     if (err == 0) {
         fuse_invalidate_attr(dvp);
+        FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE);
     }
 
     return err;
@@ -3073,6 +3086,8 @@ fuse_vnop_remove(struct vnop_remove_args *ap)
     err = fuse_internal_remove(dvp, vp, cnp, FUSE_UNLINK, context);
 
     if (err == 0) {
+        FUSE_FSEVENT(vp, VNODE_EVENT_DELETE);
+        FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE);
         fuse_vncache_purge(vp);
         fuse_invalidate_attr(dvp);
         /*
@@ -3152,6 +3167,7 @@ fuse_vnop_removexattr(struct vnop_removexattr_args *ap)
         fuse_ticket_release(fdi.tick);
         VTOFUD(vp)->c_flag |= C_TOUCH_CHGTIME;
         fuse_invalidate_attr(vp);
+        FUSE_FSEVENT(vp, VNODE_EVENT_ATTRIB);
     } else {
         if (err == ENOSYS) {
             fuse_clear_implemented(data, FSESS_NOIMPLBIT(REMOVEXATTR));
@@ -3203,14 +3219,17 @@ fuse_vnop_rename(struct vnop_rename_args *ap)
 
     if (err == 0) {
         fuse_invalidate_attr(fdvp);
+        FUSE_FSEVENT(fdvp, VNODE_EVENT_WRITE);
         if (tdvp != fdvp) {
             fuse_invalidate_attr(tdvp);
+            FUSE_FSEVENT(tdvp, VNODE_EVENT_WRITE);
         }
     }
 
     if (tvp != NULLVP) {
         if (tvp != fvp) {
             fuse_vncache_purge(tvp);
+            FUSE_FSEVENT(tvp, VNODE_EVENT_DELETE);
         }
         if (err == 0) {
 
@@ -3234,6 +3253,10 @@ fuse_vnop_rename(struct vnop_rename_args *ap)
             fuse_vncache_purge(tdvp);
         }
         fuse_vncache_purge(fdvp);
+    }
+
+    if (err == 0) {
+        FUSE_FSEVENT(fvp, VNODE_EVENT_RENAME);
     }
 
     return err;
@@ -3299,6 +3322,8 @@ fuse_vnop_rmdir(struct vnop_rmdir_args *ap)
 
     if (err == 0) {
         fuse_invalidate_attr(dvp);
+        FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE | VNODE_EVENT_LINK);
+        FUSE_FSEVENT(vp, VNODE_EVENT_DELETE);
     }
 
     return err;
@@ -3465,6 +3490,10 @@ out:
 #endif
     }
 
+    if (err == 0) {
+        FUSE_FSEVENT(vp, VNODE_EVENT_ATTRIB);
+    }
+
     return err;
 }
 
@@ -3593,6 +3622,7 @@ fuse_vnop_setxattr(struct vnop_setxattr_args *ap)
     if (!err) {
         fuse_ticket_release(fdi.tick);
         fuse_invalidate_attr(vp);
+        FUSE_FSEVENT(vp, VNODE_EVENT_ATTRIB);
         VTOFUD(vp)->c_flag |= C_TOUCH_CHGTIME;
     } else {
         if ((err == ENOSYS) || (err == ENOTSUP)) {
@@ -3697,6 +3727,7 @@ fuse_vnop_symlink(struct vnop_symlink_args *ap)
 
     if (err == 0) {
         fuse_invalidate_attr(dvp);
+        FUSE_FSEVENT(dvp, VNODE_EVENT_WRITE);
     }
 
     return err;
@@ -3956,8 +3987,10 @@ fuse_vnop_write(struct vnop_write_args *ap)
 #if M_OSXFUSE_ENABLE_BIG_LOCK
             fuse_biglock_lock(data->biglock);
 #endif
+            FUSE_FSEVENT(vp, VNODE_EVENT_WRITE | VNODE_EVENT_EXTEND);
         } else {
             fvdat->filesize = original_size;
+            FUSE_FSEVENT(vp, VNODE_EVENT_WRITE);
         }
         fuse_invalidate_attr(vp);
     }


### PR DESCRIPTION
Starting with OS X 10.11, the vnode_notify function to notify FSEvents
listeners of file changes is public. Utilize it in the same way as the
old knote code.
