### PR TITLE
Fixes #466: rename isn't updating the parent of a moved child

### DIFF
--- a/osxfuse/fuse_vnops.c
+++ b/osxfuse/fuse_vnops.c
@@ -3374,6 +3374,13 @@ fuse_vnop_rename(struct vnop_rename_args *ap)
         FUSE_KNOTE(fvp, NOTE_RENAME);
     }
 
+    /* Explicitly set the parent vnode pointer and parent node id. */
+    if (err == 0) {
+        struct fuse_vnode_data *vn_data = VTOFUD(fvp);
+        vn_data->parentvp = tdvp;
+        vn_data->parent_nodeid = VTOI(tdvp);
+    }
+
     return err;
 }
 


### PR DESCRIPTION
This change fixes osxfuse/osxfuse#466 by explicitly setting the parent vnode pointer and parent node id after a rename.

This is based off support/osxfuse-3 because that is where I've done the testing.
I tested it using the test case in the bug description.
```
cd /Volumes/loop
mkdir foo
cd foo
mkdir -p bar/baz
mkdir top
mv bar top
cd top/bar
echo 3 > ../../../file.txt
```

