### PR TITLE
Invalidate attributes in rename.

### DIFF
--- a/osxfuse/fuse_internal.c
+++ b/osxfuse/fuse_internal.c
@@ -1121,6 +1121,12 @@ fuse_internal_rename(vnode_t               fdvp,
         vnode_update_identity(fvp, tdvp, tcnp->cn_nameptr, tcnp->cn_namelen,
                               tcnp->cn_hash,
                               VNODE_UPDATE_PARENT | VNODE_UPDATE_NAME);
+
+        /* An invalidate is required here because rename updates atime.
+         * XXX: Only invalidate if the volume's been mounted without the
+         * `noatime` attribute? Are there other cases to be considered?
+         */
+        fuse_invalidate_attr(fvp);
     }
 
     return err;


### PR DESCRIPTION
This fixes osxfuse/osxfuse#568

An invalidate is required in rename because it updates atime. Without an
invalidate, stat calls to renamed files (say), that happen before the attrcache
has expired will return a wrong atime in the stat buffer. Assuming the volume
has not been mounted with the noatime attribute the following code might not
work.

```c
stat("foo.txt", &sb1);
rename("foo.txt", "bar.txt");
stat("bar.txt", &sb2);

assert(sb1.st_atime != sb2.st_atime); // Without the invalidate this assert
                                      // might fire.

sleep(1);                             // Assume attrcache timeout is 1 second.

stat("bar.txt", &sb2);
assert(sb1.st_atime != sb2.st_atime); // Now we're able to see the change in
                                      // atime. This assert is guaranteed not to
                                      // fire.
```